### PR TITLE
feat(WordScramble): add challenges

### DIFF
--- a/07-WordScramble/WordScramble/WordScramble/ContentView.swift
+++ b/07-WordScramble/WordScramble/WordScramble/ContentView.swift
@@ -41,6 +41,12 @@ struct ContentView: View {
             } message: {
                 Text(errorMessage)
             }
+            .toolbar {
+                // challenge 2
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Restart", action: startGame)
+                }
+            }
         }
     }
     
@@ -94,6 +100,10 @@ struct ContentView: View {
                 
                 // 4. Pick one random word, or use "silkworm" as a sensible default
                 rootWord = allWords.randomElement() ?? "silkworm"
+                
+                // challenge 2
+                usedWords.removeAll()
+                newWord = ""
                 
                 // If we are here everything has worked, so we can exit
                 return

--- a/07-WordScramble/WordScramble/WordScramble/ContentView.swift
+++ b/07-WordScramble/WordScramble/WordScramble/ContentView.swift
@@ -15,6 +15,8 @@ struct ContentView: View {
     @State private var errorMessage = ""
     @State private var isShowingError = false
     
+    @State private var score = 0
+    
     var body: some View {
         NavigationView {
             List {
@@ -45,6 +47,12 @@ struct ContentView: View {
                 // challenge 2
                 ToolbarItem(placement: .primaryAction) {
                     Button("Restart", action: startGame)
+                }
+                
+                // challenge 3
+                ToolbarItem(placement: .bottomBar) {
+                    Text("Score: \(score)")
+                        .font(.title3)
                 }
             }
         }
@@ -85,6 +93,9 @@ struct ContentView: View {
             usedWords.insert(answer, at: 0)
         }
         
+        // challenge 3
+        score += answer.count
+        
         newWord = ""
     }
     
@@ -104,6 +115,9 @@ struct ContentView: View {
                 // challenge 2
                 usedWords.removeAll()
                 newWord = ""
+                
+                // challenge 3
+                score = 0
                 
                 // If we are here everything has worked, so we can exit
                 return

--- a/07-WordScramble/WordScramble/WordScramble/ContentView.swift
+++ b/07-WordScramble/WordScramble/WordScramble/ContentView.swift
@@ -48,6 +48,18 @@ struct ContentView: View {
         let answer = newWord.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
         guard answer.count > 0 else { return }
         
+        // challenge 1
+        guard isLongEnough(word: answer) else {
+            wordError(title: "Word too short", message: "Word should be greater than 3 letters!")
+            return
+        }
+        
+        // challenge 1
+        guard isNotRootWord(word: answer) else {
+            wordError(title: "Root word detected", message: "You can't use the start word!")
+            return
+        }
+        
         guard isOriginal(word: answer) else {
             wordError(title: "Word used already", message: "Be more original")
             return
@@ -93,7 +105,17 @@ struct ContentView: View {
     }
     
     func isOriginal(word: String) -> Bool {
-        !usedWords.contains(word)
+        return !usedWords.contains(word)
+    }
+    
+    // challenge 1
+    func isLongEnough(word: String) -> Bool {
+        return word.count > 3
+    }
+    
+    // challenge 1
+    func isNotRootWord(word: String) -> Bool {
+        return word != rootWord
     }
     
     func isPossible(word: String) -> Bool {


### PR DESCRIPTION
# Challenges

1. Disallow answers that are shorter than three letters or are just our start word.
2. Add a toolbar button that calls startGame(), so users can restart with a new word whenever they want to.
3. Put a text view somewhere so you can track and show the player’s score for a given root word. How you calculate score is down to you, but something involving number of words and their letter count would be reasonable.

# Screenshot

<img width="968" alt="image" src="https://user-images.githubusercontent.com/57343545/212469809-43f4a97e-6d67-45cd-8ee8-28e25b917f08.png">
