### PR TITLE
feat(GuessTheFlag): add project 6 challenges

### DIFF
--- a/03-Guess the Flag/GuessTheFlag/GuessTheFlag/ContentView.swift
+++ b/03-Guess the Flag/GuessTheFlag/GuessTheFlag/ContentView.swift
@@ -41,12 +41,9 @@ struct ContentView: View {
     
     @State private var correctAnswer = Int.random(in: 0...2)
     
-    // project 6 - challenge 1
-    @State private var animationAmount = 0.0
-    
-    // project 6 - challenge 2
-    @State private var opacityAmount = 1.0
-    @State private var enabled = false
+    @State private var rotateAmount = [0.0, 0.0, 0.0]  // project 6 - challenge 1
+    @State private var opacityAmount = [1.0, 1.0, 1.0] // project 6 - challenge 2
+    @State private var scaleAmount = [1.0, 1.0, 1.0]   // project 6 - challenge 3
     
     let GAME_COUNT = 8
     
@@ -83,21 +80,13 @@ struct ContentView: View {
                     ForEach(0..<3) { number in
                         Button {
                             flagTapped(number)
-                            withAnimation {
-                                enabled.toggle()
-                                animationAmount += 360
-                                opacityAmount = 0.25
-                            }
                         } label: {
                             FlagImage(of: countries[number]) // project 3 - challenge 2
-                            // project 6 - challenge 1
-                                .rotation3DEffect(Angle(degrees: selectedAnswer == countries[number] ? animationAmount : 0), axis: (x: 0, y: 1, z: 0))
-                            // project 6 - challenge 2
-                                .opacity(enabled ? (selectedAnswer == countries[number] ? 1 : opacityAmount) : 1)
-                            // project 6 - challenge 3
-                                .scaleEffect(enabled ? (selectedAnswer == countries[number] ? 1 : opacityAmount) : 1)
-                                .animation(.default, value: enabled)
                         }
+                        .rotation3DEffect(Angle(degrees: rotateAmount[number]), axis: (x: 0, y: 1, z: 0)) // project 6 - challenge 1
+                        .opacity(opacityAmount[number])     // project 6 - challenge 2
+                        .scaleEffect(scaleAmount[number])   // project 6 - challenge 3
+                        .animation(.default, value: scaleAmount)
                     }
                 }
                 .frame(maxWidth: .infinity)
@@ -141,6 +130,15 @@ struct ContentView: View {
     func flagTapped(_ number: Int) {
         selectedAnswer = countries[number]
         
+        // project 6 - challenge 1
+        rotateAmount[number] += 360
+        
+        // project 6 - challenge 2 and 3
+        for notTapped in 0..<3 where notTapped != number {
+            opacityAmount[notTapped] = 0.25
+            scaleAmount[notTapped] = 0.85
+        }
+        
         scoreTitle = number == correctAnswer ? "Correct!" : "Wrong!" // challenge 1
         score = number == correctAnswer ? score + 1 : score
         
@@ -152,16 +150,21 @@ struct ContentView: View {
             isShowingGameOver = true
         } else {
             currentRound += 1
+            
             countries.shuffle()
             correctAnswer = Int.random(in: 0...2)
-            enabled = false
+            
+            opacityAmount = [1.0, 1.0, 1.0]
+            scaleAmount = [1.0, 1.0, 1.0]
         }
     }
     
     func restartGame() {
         countries.shuffle()
         correctAnswer = Int.random(in: 0...2)
-        enabled = false
+        
+        opacityAmount = [1.0, 1.0, 1.0]
+        scaleAmount = [1.0, 1.0, 1.0]
         
         score = 0
         currentRound = 1

--- a/03-Guess the Flag/GuessTheFlag/GuessTheFlag/ContentView.swift
+++ b/03-Guess the Flag/GuessTheFlag/GuessTheFlag/ContentView.swift
@@ -44,6 +44,10 @@ struct ContentView: View {
     // project 6 - challenge 1
     @State private var animationAmount = 0.0
     
+    // project 6 - challenge 2
+    @State private var opacityAmount = 1.0
+    @State private var enabled = false
+    
     let GAME_COUNT = 8
     
     var body: some View {
@@ -79,9 +83,17 @@ struct ContentView: View {
                     ForEach(0..<3) { number in
                         Button {
                             flagTapped(number)
+                            withAnimation {
+                                enabled.toggle()
+                                animationAmount += 360
+                                opacityAmount = 0.25
+                            }
                         } label: {
                             FlagImage(of: countries[number]) // project 3 - challenge 2
-                                .rotation3DEffect(Angle(degrees: animationAmount), axis: (x: 0, y: 1, z: 0)) // project 6 - challenge 1
+                            // project 6 - challenge 1
+                                .rotation3DEffect(Angle(degrees: selectedAnswer == countries[number] ? animationAmount : 0), axis: (x: 0, y: 1, z: 0))
+                            // project 6 - challenge 2
+                                .opacity(enabled ? (selectedAnswer == countries[number] ? 1 : opacityAmount) : 1)
                         }
                     }
                 }
@@ -125,7 +137,6 @@ struct ContentView: View {
     
     func flagTapped(_ number: Int) {
         selectedAnswer = countries[number]
-        animationAmount += 360
         
         scoreTitle = number == correctAnswer ? "Correct!" : "Wrong!" // challenge 1
         score = number == correctAnswer ? score + 1 : score
@@ -140,6 +151,9 @@ struct ContentView: View {
             currentRound += 1
             countries.shuffle()
             correctAnswer = Int.random(in: 0...2)
+            withAnimation {
+                enabled = false
+            }
         }
     }
     

--- a/03-Guess the Flag/GuessTheFlag/GuessTheFlag/ContentView.swift
+++ b/03-Guess the Flag/GuessTheFlag/GuessTheFlag/ContentView.swift
@@ -142,7 +142,9 @@ struct ContentView: View {
         scoreTitle = number == correctAnswer ? "Correct!" : "Wrong!" // challenge 1
         score = number == correctAnswer ? score + 1 : score
         
-        isShowingScore = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            isShowingScore = true
+        }
     }
     
     func askQuestion() {

--- a/03-Guess the Flag/GuessTheFlag/GuessTheFlag/ContentView.swift
+++ b/03-Guess the Flag/GuessTheFlag/GuessTheFlag/ContentView.swift
@@ -96,6 +96,7 @@ struct ContentView: View {
                                 .opacity(enabled ? (selectedAnswer == countries[number] ? 1 : opacityAmount) : 1)
                             // project 6 - challenge 3
                                 .scaleEffect(enabled ? (selectedAnswer == countries[number] ? 1 : opacityAmount) : 1)
+                                .animation(.default, value: enabled)
                         }
                     }
                 }
@@ -153,15 +154,14 @@ struct ContentView: View {
             currentRound += 1
             countries.shuffle()
             correctAnswer = Int.random(in: 0...2)
-            withAnimation {
-                enabled = false
-            }
+            enabled = false
         }
     }
     
     func restartGame() {
         countries.shuffle()
         correctAnswer = Int.random(in: 0...2)
+        enabled = false
         
         score = 0
         currentRound = 1

--- a/03-Guess the Flag/GuessTheFlag/GuessTheFlag/ContentView.swift
+++ b/03-Guess the Flag/GuessTheFlag/GuessTheFlag/ContentView.swift
@@ -41,6 +41,9 @@ struct ContentView: View {
     
     @State private var correctAnswer = Int.random(in: 0...2)
     
+    // project 6 - challenge 1
+    @State private var animationAmount = 0.0
+    
     let GAME_COUNT = 8
     
     var body: some View {
@@ -78,6 +81,7 @@ struct ContentView: View {
                             flagTapped(number)
                         } label: {
                             FlagImage(of: countries[number]) // project 3 - challenge 2
+                                .rotation3DEffect(Angle(degrees: animationAmount), axis: (x: 0, y: 1, z: 0)) // project 6 - challenge 1
                         }
                     }
                 }
@@ -121,6 +125,7 @@ struct ContentView: View {
     
     func flagTapped(_ number: Int) {
         selectedAnswer = countries[number]
+        animationAmount += 360
         
         scoreTitle = number == correctAnswer ? "Correct!" : "Wrong!" // challenge 1
         score = number == correctAnswer ? score + 1 : score

--- a/03-Guess the Flag/GuessTheFlag/GuessTheFlag/ContentView.swift
+++ b/03-Guess the Flag/GuessTheFlag/GuessTheFlag/ContentView.swift
@@ -94,6 +94,8 @@ struct ContentView: View {
                                 .rotation3DEffect(Angle(degrees: selectedAnswer == countries[number] ? animationAmount : 0), axis: (x: 0, y: 1, z: 0))
                             // project 6 - challenge 2
                                 .opacity(enabled ? (selectedAnswer == countries[number] ? 1 : opacityAmount) : 1)
+                            // project 6 - challenge 3
+                                .scaleEffect(enabled ? (selectedAnswer == countries[number] ? 1 : opacityAmount) : 1)
                         }
                     }
                 }


### PR DESCRIPTION
# Challenges

1. When you tap a flag, make it spin around 360 degrees on the Y axis.
1. Make the other two buttons fade out to 25% opacity.
1. Add a third effect of your choosing to the two flags the user didn’t choose – maybe make them scale down? Or flip in a different direction? Experiment!

# Demo

<div align="center">

https://user-images.githubusercontent.com/57343545/213643841-5adcd906-8732-4945-81de-62bb51e7c390.mov

</br>
</br>

w/ delayed alert

![Project-6-Final](https://user-images.githubusercontent.com/57343545/213652174-86d1579e-9996-4aef-83da-a1b48e83f24b.gif)

</div>

</br>
</br>

<samp> Edit: added a demo for delayed alert</samp>